### PR TITLE
스터디 신청 및 만들기, 로딩 페이지 수정

### DIFF
--- a/app/approval/page.tsx
+++ b/app/approval/page.tsx
@@ -98,7 +98,7 @@ export default function ApprovalPage() {
         ) : (
           <Link href="/waiting">
             <Button className="border-1 w-60 flex-[2] border-solid">
-              스터디 신청하기
+              대기중인 요청 확인
             </Button>
           </Link>
         )}

--- a/app/approval/page.tsx
+++ b/app/approval/page.tsx
@@ -1,20 +1,19 @@
-import Link from 'next/link'
 import BtnBackIcon from '~/assets/btn_back.svg'
 import BtnMoreVertical from '~/assets/icon_more-vertical.svg'
+
+import Link from 'next/link'
 import { Button } from '~/components/ui/button'
 import { Chip } from '~/components/ui/chip'
 
-//  스터디 신청자 페이지
-
-export default function ApplyIntroPage() {
+export default function ApprovalPage() {
   const AppliedStudyTitle = '피그마 정복하기'
   const TestText = '받아온 데이터 출력하기'
-  const applynum = 2
+  const applynum: number = 1
   const maxnum = 4
   return (
     <section className="flex min-h-dvh flex-col bg-white pb-8">
       <div className="fixed top-4 flex flex-row space-x-28 px-3 pt-3">
-        <a href="search">
+        <a href="# ">
           <BtnBackIcon />
         </a>
         <h2 className="invisible font-bold">스터디 지원하기</h2>
@@ -75,6 +74,12 @@ export default function ApplyIntroPage() {
           <h2 className="font-bold">스터디 기간</h2>
           <h2 className="font-medium">{TestText}</h2>
         </div>
+        <div className="space-y-2 px-[120px] pt-8">
+          <Link href="established ">
+            <p className="text-meetie-blue-4 underline">스터디 마감하기</p>
+          </Link>
+        </div>
+
         <div className="space-y-2 pt-20"></div>
       </div>
 
@@ -86,11 +91,31 @@ export default function ApplyIntroPage() {
             명
           </p>
         </div>
-        <Link href="/apply">
-          <Button className="border-1 w-60 flex-[2] border-solid">
-            스터디 신청하기
+        {applynum === 0 ? (
+          <Button className="border-1 w-[240px] border-solid bg-gray-400">
+            아직 대기 인원이 없습니다
           </Button>
-        </Link>
+        ) : (
+          <Link href="/waiting">
+            <Button className="border-1 w-60 flex-[2] border-solid">
+              스터디 신청하기
+            </Button>
+          </Link>
+        )}
+        {/* if (applynum===0)
+        {
+          <Button className="border-1 w-60 flex-[2] border-solid">
+            아직 대기 인원이 없습니다
+          </Button>
+        }
+        else
+        {
+          <Link href="/apply">
+            <Button className="border-1 w-60 flex-[2] border-solid">
+              스터디 신청하기
+            </Button>
+          </Link>
+        } */}
       </div>
     </section>
   )

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,80 +1,73 @@
-import BtnBackIcon from '~/assets/btn_back.svg'
-import { Input } from '~/components/ui/input'
-import { Progress } from '~/components/ui/progress'
-import { Textarea } from '~/components/ui/textarea'
-
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '~/components/ui/dropdown-menu'
-import { Button } from '~/components/ui/button'
 import Link from 'next/link'
-
-// 확인 주소 http://localhost:3000/create
+import BtnBackIcon from '~/assets/btn_back.svg'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Textarea } from '~/components/ui/textarea'
 
 export default function CreatePage() {
   return (
-    <div className="flex min-h-dvh w-full flex-col items-center justify-center bg-[#F7F3FF] py-24">
-      <div className="relative h-40 w-full bg-slate-600">
-        <div className="absolute inset-x-0 top-0 flex flex-row">
-          {/* 헤더 */}
-          <a href="/">
-            <BtnBackIcon />
-          </a>
-          <h2>스터디 만들기</h2>
-        </div>
+    <section className="flex min-h-dvh flex-col bg-white pb-8">
+      <div className="fixed top-4 flex flex-row space-x-28 px-3 pt-3">
+        <a href="/search">
+          <BtnBackIcon />
+        </a>
+        <h2 className="font-bold">스터디 만들기</h2>
+        <p>
+          1 / <span className="text-gray-300">2</span>{' '}
+        </p>
       </div>
-      <div>
-        {/* 관련 오류 해결 안됨 */}
-        <Progress value={2} />
-      </div>
-      <div>
-        <div>
-          <h2>모집 직군 </h2>
-          <DropdownMenu>
-            <DropdownMenuTrigger>Open</DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>My Account</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem>Profile</DropdownMenuItem>
-              <DropdownMenuItem>Billing</DropdownMenuItem>
-              <DropdownMenuItem>Team</DropdownMenuItem>
-              <DropdownMenuItem>Subscription</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+      <div>{/* 여기는 progress bar */}</div>
+      <div className="space-y-0 px-3">
+        <div className="space-y-2 pt-20">
+          <h2 className="font-bold">모집 직군</h2>
+          <h2 className="font-medium">hello</h2>
         </div>
-
-        <div>
-          <h2>주제</h2>
+        <div className="space-y-2 pt-10">
+          <h2 className="font-bold">주제</h2>
           <Input
             placeholder="스터디의 주제를 작성해주세요"
             className="required"
             maxLength={20}
           />
         </div>
-        <div>
-          <h2>목표</h2>
-          <Input placeholder="스터디의 목표를 간단히 작성해주세요" />
+        <div className="space-y-2 pt-10">
+          <h2 className="font-bold">목표</h2>
+          <Input
+            placeholder="스터디의 목표를 간단히 작성해주세요"
+            className="required"
+            maxLength={20}
+          />
         </div>
-        <div>
-          <h2>소개</h2>
-          <Textarea placeholder="스터디를 설명해보세요" />
-        </div>
-        <div className="flex">
-          <Button variant="secondary" className="flex-1">
-            이전
-          </Button>
-          <Link href="createsec">
-            <Button className="border-1 flex-[2] border-solid bg-meetie-blue-2">
-              다음
-            </Button>
-          </Link>
+        <div className="space-y-2 pt-10">
+          <h2 className="font-bold">소개</h2>
+          <Textarea
+            placeholder="스터디를 설명해보세요"
+            className="resize-none"
+            rows={6}
+          />
         </div>
       </div>
-    </div>
+
+      <div className="fixed bottom-8 flex items-center justify-center space-x-2 px-[20px]">
+        <Link href="search">
+          <Button
+            variant="secondary"
+            className="w-[110px] flex-initial border-[1px] border-gray-200"
+          >
+            이전
+          </Button>
+        </Link>
+        <Link href="createsec">
+          <Button className="w-[220px] flex-initial border-[1px] border-solid">
+            다음
+          </Button>
+        </Link>
+
+        {/* 비활성화 상태일때 */}
+        {/* <Button className="w-[220px] flex-initial border-[1px] border-solid bg-meetie-blue-2">
+          다음_off
+        </Button> */}
+      </div>
+    </section>
   )
 }

--- a/app/createsec/page.tsx
+++ b/app/createsec/page.tsx
@@ -1,33 +1,26 @@
 'use client'
 
 import * as React from 'react'
-import BtnBackIcon from '~/assets/btn_back.svg'
-import { Input } from '~/components/ui/input'
-import { Progress } from '~/components/ui/progress'
+import { format } from 'date-fns'
+import { Calendar as CalendarIcon } from 'lucide-react'
+
+import { cn } from '../../src/utils/cn'
+import { Button } from '~/components/ui/button'
 import { Calendar } from '~/components/ui/calendar'
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '~/components/ui/popover'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '~/components/ui/dropdown-menu'
-import { Button } from '~/components/ui/button'
+import BtnBackIcon from '~/assets/btn_back.svg'
 import { Textarea } from '~/components/ui/textarea'
-import { Calendar as CalendarIcon } from 'lucide-react'
-
-import { format } from 'date-fns'
-import { cn } from '~/utils/cn'
-import { Chip } from '~/components/ui/chip'
 import Link from 'next/link'
 
 export default function CreatePageSecond() {
+  const [startdate, setStartDate] = React.useState<Date>()
+  const [enddate, setEndDate] = React.useState<Date>()
+  const [regulardate, setRegularDate] = React.useState<Date>()
+
   const [count, setCount] = React.useState<number>(0)
 
   const handleIncrease = () => {
@@ -37,129 +30,163 @@ export default function CreatePageSecond() {
   const handleDecrease = () => {
     setCount(count > 0 ? count - 1 : 0) // 최소 0명으로 제한
   }
-  const [date, setDate] = React.useState<Date>()
-  const [date2, setDate2] = React.useState<Date>()
 
   return (
-    <div className="flex min-h-dvh w-full flex-col items-center justify-center bg-[#F7F3FF] py-24">
-      <div className="flex flex-row">
-        {/* 헤더 */}
-        <a href="/">
+    <section className="flex min-h-dvh flex-col bg-white pb-8">
+      <div className="fixed top-4 flex flex-row space-x-28 px-3 pt-3">
+        <a href="/create">
           <BtnBackIcon />
         </a>
-        <h2>스터디 만들기</h2>
+        <h2 className="font-bold">스터디 만들기</h2>
+        <p>
+          2 / <span className="text-gray-300">2</span>
+        </p>
       </div>
-      <div>
-        {/* 관련 오류 해결 안됨 */}
-        <Progress value={2} />
-      </div>
-      <div>
-        <div>
-          <h2>진행방식과 커리큘럼</h2>
-          <Textarea placeholder="스터디의 진행 방식과 커리큘럼을 작성해주세요" />
+      <div>{/* 여기는 progress bar */}</div>
+      <div className="space-y-0 px-3">
+        <div className="space-y-2 pt-20">
+          <h2 className="font-bold">진행방식과 커리큘럼</h2>
+          <Textarea
+            placeholder="스터디의 진행방식과 커리큘럼을 소개해주세요"
+            className="resize-none border-gray-400"
+            rows={6}
+          />
         </div>
 
-        <div className="flex flex-row">
-          <div>
-            <h2>시작일</h2>
+        <div className="flex flex-row space-x-3 pt-10">
+          <div className="items-center">
+            <h2 className="font-bold leading-3">시작일</h2>
             <Popover>
               <PopoverTrigger asChild>
                 <Button
                   variant={'outline'}
                   className={cn(
-                    'w-[1] justify-start text-left font-normal',
-                    !date && 'text-muted-foreground',
+                    'mt-3 w-[170px] justify-start border-gray-400 text-left font-normal text-black',
+                    !enddate && 'text-muted-foreground',
                   )}
                 >
-                  {date ? format(date, 'PPP') : <span>날짜 선택</span>}
+                  {enddate ? (
+                    format(enddate, 'yyyy년 MM월 dd일')
+                  ) : (
+                    <span className="text-gray-400">날짜 선택</span>
+                  )}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-auto bg-white p-0">
                 <Calendar
                   mode="single"
-                  selected={date}
-                  onSelect={setDate}
+                  selected={enddate}
+                  onSelect={setEndDate}
                   initialFocus
                 />
               </PopoverContent>
             </Popover>
           </div>
-          <div>
-            <h2>마감일</h2>
+          <div className="items-center">
+            <h2 className="font-bold leading-3">종료일</h2>
             <Popover>
               <PopoverTrigger asChild>
                 <Button
                   variant={'outline'}
                   className={cn(
-                    'w-[1] justify-start text-left font-normal',
-                    !date2 && 'text-muted-foreground',
+                    'mt-3 w-[170px] justify-start border-gray-400 text-left font-normal text-black',
+                    !startdate && 'text-muted-foreground',
                   )}
                 >
-                  {date2 ? format(date2, 'PPP') : <span>날짜 선택</span>}
+                  {startdate ? (
+                    format(startdate, 'yyyy년 MM월 dd일')
+                  ) : (
+                    <span className="text-gray-400">날짜 선택</span>
+                  )}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-auto bg-white p-0">
                 <Calendar
                   mode="single"
-                  selected={date2}
-                  onSelect={setDate2}
+                  selected={startdate}
+                  onSelect={setStartDate}
                   initialFocus
                 />
               </PopoverContent>
             </Popover>
           </div>
         </div>
-        <p className="text-left">스터디 시작일이 모집 마감일로 설정됩니다</p>
-        <div>
-          <h2>스터디 모집인원</h2>
-          <div>
+        <p className="pt-2 text-xs text-meetie-blue-4">
+          스터디 시작일이 모집 마감일로 설정됩니다
+        </p>
+        <div className="flex flex-row space-x-3 pt-10">
+          <div className="items-center">
+            <h2 className="font-bold leading-3">정기일정</h2>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant={'outline'}
+                  className={cn(
+                    'mt-3 w-[170px] justify-start border-gray-400 text-left font-normal text-black',
+                    !regulardate && 'text-muted-foreground',
+                  )}
+                >
+                  {regulardate ? (
+                    format(regulardate, 'yyyy년 MM월 dd일')
+                  ) : (
+                    <span className="text-gray-400">날짜 선택</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto bg-white p-0">
+                <Calendar
+                  mode="single"
+                  selected={regulardate}
+                  onSelect={setRegularDate}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        </div>
+
+        <div className="pt-10">
+          <h2 className="font-bold leading-3">스터디 모집 인원</h2>
+          <div className="mt-3 h-[45px] w-[1] items-center justify-center rounded-md border-[1px] border-gray-400">
             <button onClick={handleDecrease}>-</button>
             <span style={{ margin: '0 10px' }}>{count}</span>
             <button onClick={handleIncrease}>+</button>
           </div>
-          <p className="text-xs">4~8명이 적당한 스터디 인원이에요</p>
         </div>
-        <div>
-          <h2>관련태그</h2>
 
-          <div className="... h-42 grid grid-cols-3 content-evenly gap-2">
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              온라인
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              오프라인
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              프론트엔드
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              UX/UI
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              PM
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              어플
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              웹
-            </Chip>
-            <Chip data-state="on" className="border-1 text-xs text-black">
-              사이드프로젝트
-            </Chip>
-          </div>
-          <p className="text-xs">최대 10개까지 선택이 가능해요</p>
-        </div>
-        <div className="flex">
-          <Link href="create">
-            <Button variant="secondary" className="flex-1">
-              이전
-            </Button>
-          </Link>
+        <p className="pt-2 text-xs text-meetie-blue-4">
+          4~8명이 적당한 스터디 인원이에요
+        </p>
 
-          <Button className="border-1 flex-[2] border-solid">작성완료 </Button>
+        <div className="pt-10">
+          <h2 className="font-bold leading-3">관련 태그</h2>
+          <div className="mt-3 h-[80px] w-[1] items-center justify-center rounded-md border-[1px] border-gray-400"></div>
         </div>
+        <p className="pt-2 text-xs text-meetie-blue-4">
+          최대 4개까지 선택이 가능합니다
+        </p>
       </div>
-    </div>
+
+      <div className="fixed bottom-8 flex items-center justify-center space-x-2 px-[20px]">
+        <Link href="create">
+          <Button
+            variant="secondary"
+            className="w-[110px] flex-initial border-[1px] border-gray-200"
+          >
+            이전
+          </Button>
+        </Link>
+        <Link href="approval">
+          <Button className="w-[220px] flex-initial border-[1px] border-solid">
+            작성완료
+          </Button>
+        </Link>
+
+        {/* 비활성화 상태일때 */}
+        {/* <Button className="w-[220px] flex-initial border-[1px] border-solid bg-meetie-blue-2">
+          내용이 부족해요!
+        </Button> */}
+      </div>
+    </section>
   )
 }

--- a/app/established/page.tsx
+++ b/app/established/page.tsx
@@ -1,0 +1,35 @@
+import BtnBackIcon from '~/assets/btn_back.svg'
+import BtnMoreVertical from '~/assets/icon_more-vertical.svg'
+import { Button } from '~/components/ui/button'
+
+export default function EstablishedPage() {
+  return (
+    <section className="flex min-h-dvh flex-col bg-white pb-8">
+      <div className="invisible fixed top-4 flex flex-row space-x-28 px-3 pt-3">
+        <a href="# ">
+          <BtnBackIcon />
+        </a>
+        <h2 className="invisible font-bold">스터디 지원하기</h2>
+        <BtnMoreVertical />
+      </div>
+
+      <div className="px-3">
+        <div className="space-y-2 pt-20">
+          <h1 className="text-2xl font-bold">멤버들이 모두 모여</h1>
+          <h1 className="text-2xl font-bold">스터디룸이 생성되었어요👏</h1>
+          <p className="text-xs">모두 함께 스터디 완주를 하는 그날까지!</p>
+        </div>
+      </div>
+      <div className="space-y-2 pt-20">
+        <div className="h-[250px] w-[375px] bg-meetie-blue-5 text-white">
+          여기에 나중에 스터디원 카드들이 수동으로 slider
+        </div>
+      </div>
+      <div className="fixed bottom-8 flex items-center justify-center space-x-4 px-3">
+        <Button className="border-1 w-[350px] border-solid">
+          스터디룸 보러가기
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/app/waiting/page.tsx
+++ b/app/waiting/page.tsx
@@ -1,0 +1,16 @@
+import BtnBackIcon from '~/assets/btn_back.svg'
+import BtnMoreVertical from '~/assets/icon_more-vertical.svg'
+
+export default function WaitingListPage() {
+  return (
+    <section className="flex min-h-dvh flex-col bg-white pb-8">
+      <div className="fixed top-4 flex flex-row space-x-28 px-3 pt-3">
+        <a href="# ">
+          <BtnBackIcon />
+        </a>
+        <h2 className="invisible font-bold">스터디 지원하기</h2>
+        <BtnMoreVertical />
+      </div>
+    </section>
+  )
+}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -35,10 +35,10 @@ function Calendar({
           'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
         row: 'flex w-full mt-2',
         cell: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
-        day: cn(
-          buttonVariants({ variant: 'ghost' }),
-          'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
-        ),
+        // day: cn(
+        //   buttonVariants({ variant: 'ghost' }),
+        //   'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+        // ),
         day_range_end: 'day-range-end',
         day_selected:
           'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',


### PR DESCRIPTION
## 📌 요약

> 스터디 신청 페이지, 만들기 페이지, 로딩 페이지 퍼블리싱을 진행했습니다. 

- close #[27]

## 📝 작업 내용

- 스터디 신청 페이지 : 컴포넌트들의 위치를 일부 수정하였습니다 
- 스터디 개설 페이지: 컴포넌트 개발을 진행했습니다
- 스터디 세부 정보 페이지: 프로필 부분을 제외한 나머지를 완성했습니다 
- 로딩 창 : 이미지 카드 슬라이드 부분을 제외한 나머지를 완성했습니

## 📚 참고

- 배포에 문제가 되었던 calender 부분 수정했습니다. 
- 스터디 신청 페이지에서 신청서 제출하기를 누른 다음에 정상 제출 되었다는 이벤트 추가 개발이 필요할 것 같습니다 
- 스터디 개설 페이지의 미완성 부분에 대한 추가 개발이 필요합니다(time picker관련 라이브러리 추가 조사 필요)
- 스터디 상세 정보페이지의 프로필 부분에 대한 추가 개발이 필요합니다 
- 
## 💖 리뷰 요구사항

-

## 🖥️ 스크린샷
- 스터디 신청 페이지
<img width="284" alt="image" src="https://github.com/user-attachments/assets/90931b8a-89e2-47cf-932b-3e9e3c2f7004">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/612bab84-4a9c-4b58-bdf7-628f830433d4">
- 스터디 개설 페이지
<img width="280" alt="image" src="https://github.com/user-attachments/assets/fdc36598-fc07-4524-a376-88b5d1dbbb6c">
<img width="313" alt="image" src="https://github.com/user-attachments/assets/08c92db3-96ee-4327-a3e1-0392cc1e5f10">
- 스터디 상세 정보 페이지
<img width="280" alt="image" src="https://github.com/user-attachments/assets/250c34ac-fe76-4fb3-b8c1-d3b2c23c530f">
<img width="289" alt="image" src="https://github.com/user-attachments/assets/3dfbe894-b6d1-4805-812d-638f86dedd78">
<img width="446" alt="image" src="https://github.com/user-attachments/assets/ac85873c-5aba-491e-95c8-bd24c6144fb3">

